### PR TITLE
Fix ModSecurity build: use --recursive for submodule update to include Mbed TLS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,7 @@ RUN git clone https://github.com/yaoweibin/ngx_http_substitutions_filter_module 
 
 # Build ModSecurity
 RUN cd ModSecurity && \
-    git submodule init && \
-    git submodule update && \
+    git submodule update --init --recursive && \
     ./build.sh && \
     ./configure && \
     make && \


### PR DESCRIPTION
## Summary
- ModSecurity `./configure` was failing with "Mbed TLS was not found" because `git submodule init && git submodule update` doesn't recurse into nested submodules
- Mbed TLS is a nested submodule added as a required dependency to ModSecurity v3/master
- Fix: replace with `git submodule update --init --recursive`

## Test plan
- [x] Triggered full build workflow on this branch (`force_build=true`) — run [25210838940](https://github.com/rweijnen/nginx-with-modsecurity/actions/runs/25210838940)
- [x] Docker build completed successfully (both AMD64 and ARM64)
- [x] ModSecurity compiled without errors
- [x] Post-build vulnerability scan: clean (0 critical/high)
- [x] Only failure was the version-commit step trying to `git pull main` from a non-main branch — expected and harmless

Fixes #6